### PR TITLE
Variable line width added to lineChart

### DIFF
--- a/examples/Main.elm
+++ b/examples/Main.elm
@@ -39,6 +39,12 @@ lineGraphAttributes =
     , options = [ Color "blue", YTickmarks 4, Scale 1.0 1.0 ]
     }
 
+lineGraphAttributes2 =
+    { graphHeight = 100
+    , graphWidth = 400
+    , options = [ Color "blue", YTickmarks 4, LineWidth 3, Scale 1.0 1.0 ]
+    }
+
 scatterPlotAttributes =
     { graphHeight = 200
     , graphWidth = 200
@@ -116,6 +122,7 @@ mainColumn model =
             , row [] [ lineChart lineGraphAttributes lineData |> Element.html ]
             , row [] [ barChart barGraphAttributes barData |> Element.html ]
             , row [] [ scatterPlot scatterPlotAttributes scatterData |> Element.html]
+            , row [] [ lineChart lineGraphAttributes2 lineData |> Element.html ]
             ]
         ]
 

--- a/src/SimpleGraph.elm
+++ b/src/SimpleGraph.elm
@@ -67,6 +67,7 @@ type Option
     | YTickmarks Int
     | DeltaX Float
     | Scale Float Float
+    | LineWidth Float
 
 
 {-| A DataWindow is a rectangle which determines
@@ -447,7 +448,8 @@ segmentToSVG options ( ( x1, y1 ), ( x2, y2 ) ) =
         , SA.x2 (String.fromFloat x2)
         , SA.y2 (String.fromFloat y2)
         , SA.stroke <| lineColor options
-        , SA.strokeWidth "1"
+        --, SA.strokeWidth "1"
+        , SA.strokeWidth <| String.fromFloat ( lineWidth options)
         ]
         []
 
@@ -533,6 +535,21 @@ scale_ option =
     case option of
         Scale kx ky ->
             Just ( kx, ky )
+
+        _ ->
+            Nothing
+
+
+lineWidth : List Option -> Float
+lineWidth options =
+    findMap lineWidth_ options |> Maybe.withDefault 1.0
+
+
+lineWidth_ : Option -> Maybe Float
+lineWidth_ option =
+    case option of
+        LineWidth k ->
+            Just k
 
         _ ->
             Nothing


### PR DESCRIPTION
Motivation
The original script could only plot lineCharts with a default stroke width of 1.

Modification
- The Option type LineWidth was added as float.
- The function segmentToSVG now handles variable SA.strokeWidth values.
- The functions lineWidth and lineWidth_ were added, based on lineColor and lineColor_.

Result
LineCharts now can display lines of variable thickness.

Closes: #1